### PR TITLE
Move check for a git repository

### DIFF
--- a/cmd/git-pair/end.go
+++ b/cmd/git-pair/end.go
@@ -7,11 +7,6 @@ import (
 )
 
 func End() {
-	if !git.IsGitRepo() {
-		fmt.Println("Not executed from a git repository")
-		return
-	}
-
 	err := git.DisablePairingMode()
 
 	if err != nil {

--- a/cmd/git-pair/info.go
+++ b/cmd/git-pair/info.go
@@ -8,11 +8,6 @@ import (
 )
 
 func Info() {
-	if !git.IsGitRepo() {
-		fmt.Println("Not executed from a git repository")
-		return
-	}
-
 	if !git.PairingModeEnabled() {
 		fmt.Println("Pairing mode is not enabled")
 		return

--- a/cmd/git-pair/main.go
+++ b/cmd/git-pair/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
 
 	"github.com/inverse/git-pair/internal/diagnostics"
+	"github.com/inverse/git-pair/internal/git"
 	"github.com/urfave/cli/v2"
 )
 
@@ -17,6 +19,13 @@ func main() {
 	app := &cli.App{
 		Version: diagnostics.Version,
 		Usage:   "A tool to make it easier for git based pairing for co-authoring commits",
+		Before: func(cCtx *cli.Context) error {
+			if !git.IsGitRepo() {
+				return errors.New("Not executed from a git repository")
+			}
+
+			return nil
+		},
 		Commands: []*cli.Command{
 			{
 				Name:    "start",

--- a/cmd/git-pair/start.go
+++ b/cmd/git-pair/start.go
@@ -10,11 +10,6 @@ import (
 )
 
 func Start() {
-	if !git.IsGitRepo() {
-		fmt.Println("Not executed from a git repository")
-		return
-	}
-
 	localContributors, err := contributors.GetLocalContributors()
 	if err != nil {
 		fmt.Printf("Failed to load local contributors: %s\n", err)


### PR DESCRIPTION
Using the `Before` function we avoid having the same check duplicated in
all commands.
