### PR TITLE
Bump golangci-lint to 2.1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           file: .mise.toml
           field: tools.golangci-lint
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: 'v${{ steps.get-golangci-lint-version.outputs.value }}'
   pre-commit:

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 golang = "1.22.10"
-golangci-lint = "1.64.8"
+golangci-lint = "2.1.6"
 goreleaser = "2.5.0"
 nfpm = "2.41.1"
 task = "3.40.1"

--- a/cmd/git-pair/main.go
+++ b/cmd/git-pair/main.go
@@ -20,7 +20,7 @@ func main() {
 		Usage:   "A tool to make it easier for git based pairing for co-authoring commits",
 		Before: func(cCtx *cli.Context) error {
 			if !git.IsGitRepo() {
-				return errors.New("Not executed from a git repository")
+				return errors.New("not executed from a git repository")
 			}
 
 			return nil

--- a/cmd/git-pair/start.go
+++ b/cmd/git-pair/start.go
@@ -12,12 +12,12 @@ import (
 func Start() error {
 	localContributors, err := contributors.GetLocalContributors()
 	if err != nil {
-		return fmt.Errorf("Failed to load local contributors: %w", err)
+		return fmt.Errorf("failed to load local contributors: %w", err)
 	}
 
 	repoContributors, err := git.GetRepoContributors()
 	if err != nil {
-		return fmt.Errorf("Failed to load repo contributors: %w", err)
+		return fmt.Errorf("failed to load repo contributors: %w", err)
 	}
 
 	allContributors := util.UniqueStrings(append(localContributors, repoContributors...))

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkk
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
 github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
@@ -28,8 +26,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/urfave/cli/v2 v2.27.4 h1:o1owoI+02Eb+K107p27wEX9Bb8eqIoZCfLXloLUSWJ8=
-github.com/urfave/cli/v2 v2.27.4/go.mod h1:m4QzxcD2qpra4z7WhzEGn74WZLViBnMpb1ToCAKdGRQ=
 github.com/urfave/cli/v2 v2.27.6 h1:VdRdS98FNhKZ8/Az8B7MTyGQmpIr36O1EHybx/LaZ4g=
 github.com/urfave/cli/v2 v2.27.6/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=

--- a/internal/contributors/contributors.go
+++ b/internal/contributors/contributors.go
@@ -21,7 +21,13 @@ func GetLocalContributors() ([]string, error) {
 		return nil, err
 	}
 
-	defer file.Close()
+	defer func() {
+		closeErr := file.Close()
+
+		if closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
 
 	var lines []string
 	scanner := bufio.NewScanner(file)
@@ -29,5 +35,7 @@ func GetLocalContributors() ([]string, error) {
 		lines = append(lines, scanner.Text())
 	}
 
-	return lines, scanner.Err()
+	err = scanner.Err()
+
+	return lines, err
 }


### PR DESCRIPTION
- Bump golangci-lint to 2.1.6
- Fix new errors